### PR TITLE
Fixing .org typo

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -48,7 +48,7 @@ and undergoing Incubation at the Apache Software Foundation (ASF).</p>
 <p><img alt="Trends" src="images/demo_trends.png" /></p>
 <h3 id='youcanalsorunsimplengramanalysesoflistcontent'>You can also run simple n-gram analyses of list content<a href='#youcanalsorunsimplengramanalysesoflistcontent' style='color: rgba(0,0,0,0);'>&para;</a></h3>
 <p><img alt="N-grams" src="images/demo_ngrams.png" /></p>
-<p>See <a href="https://lists.apache.org">https://lists.apache.org.org</a> for a live demo;
+<p>See <a href="https://lists.apache.org">https://lists.apache.org</a> for a live demo;
 Pony Mail is currently running on the full mail archives of all Apache projects.</p>
 <p>Pony Mail works in both public, private and mixed-mode, allowing you
 to have one unified place for all your communication, both public and


### PR DESCRIPTION
Just removing an extra .org in lists.apache.org.org