### PR TITLE
Remove incubation disclaimers and references — Pony Mail is now a TLP

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -95,25 +95,13 @@ Currently, we consist of (in alphabetical order):</p>
 <li>Ulises Cerviño Beresi / ucb - committer</li>
 </ul>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/building.html
+++ b/content/building.html
@@ -51,25 +51,13 @@
 <li>Announce the new release :)</li>
 </ul>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/contribute.html
+++ b/content/contribute.html
@@ -48,7 +48,7 @@ https://github.com/apache/incubator-ponymail-site/issues](https://github.com/apa
 <ul>
 <li><a href="/source.html">Fork the repo</a></li>
 <li>Subscribe to the Pony Mail dev list:<ul>
-<li>Either send an email to dev-subscribe@ponymail.incubator.apache.org OR</li>
+<li>Either send an email to dev-subscribe@ponymail.apache.org OR</li>
 <li>Visit <a href="https://lists.apache.org/list.html?dev@ponymail.apache.org">https://lists.apache.org/list.html?dev@ponymail.apache.org</a> (You can use Google+ or ASF OAuth)</li>
 </ul>
 </li>
@@ -119,25 +119,13 @@ a clean way</p>
 <h3 id='buildingreleases'>Building releases<a href='#buildingreleases' style='color: rgba(0,0,0,0);'>&para;</a></h3>
 <p>Please see <a href="building.html">this document</a> for details on building a release.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs.html
+++ b/content/docs.html
@@ -57,25 +57,13 @@
 <h3 id='api'>API<a href='#api' style='color: rgba(0,0,0,0);'>&para;</a></h3>
 <p>There is a page which <a href="/docs/api.html">describes the API</a></p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/api.html
+++ b/content/docs/api.html
@@ -264,25 +264,13 @@ For email ID, the thread is returned.</p>
 TBA
 </pre>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/archiving.html
+++ b/content/docs/archiving.html
@@ -123,25 +123,13 @@ setting for this (in <code>ponymail.cfg</code>). </p>
   cropout:  <([a-z]+)\.bar\.tld> <\1.blorg.bar.tld>
 </pre>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/building.html
+++ b/content/docs/building.html
@@ -52,25 +52,13 @@ $
 <p>You may choose to commit the initial JS changes first before 
 committing the new combined JS, but that's up to you.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/contributing.html
+++ b/content/docs/contributing.html
@@ -47,36 +47,24 @@ us know either through an issue/PR here or on the mailing list.</p>
 and pull requests are welcome.</p>
 <h2 id='mailinglists'>Mailing lists<a href='#mailinglists' style='color: rgba(0,0,0,0);'>&para;</a></h2>
 <p>Developers list:
- - list: dev@ponymail.incubator.apache.org
- - subscribe addr: dev-subscribe@ponymail.incubator.apache.org
- - Online version: http://lists.apache.org/list.html?dev@ponymail.incubator.apache.org</p>
+ - list: dev@ponymail.apache.org
+ - subscribe addr: dev-subscribe@ponymail.apache.org
+ - Online version: http://lists.apache.org/list.html?dev@ponymail.apache.org</p>
 <p>Issues list:
- - list: issues@ponymail.incubator.apache.org
- - subscribe addr: issues-subscribe@ponymail.incubator.apache.org
- - Online version: http://lists.apache.org/list.html?bugs@ponymail.incubator.apache.org</p>
+ - list: issues@ponymail.apache.org
+ - subscribe addr: issues-subscribe@ponymail.apache.org
+ - Online version: http://lists.apache.org/list.html?bugs@ponymail.apache.org</p>
 <h2 id='chat'>Chat<a href='#chat' style='color: rgba(0,0,0,0);'>&para;</a></h2>
 <p>IRC:
     - #ponymail on Freenode</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/design-notes.html
+++ b/content/docs/design-notes.html
@@ -88,25 +88,13 @@ http://markmail.org/message/oanktcpxlxkmyora</p>
 <h3 id='permalinkdesign'>Permalink design<a href='#permalinkdesign' style='color: rgba(0,0,0,0);'>&para;</a></h3>
 <p>TBA</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/importing.html
+++ b/content/docs/importing.html
@@ -88,25 +88,13 @@ They can be found in gzip format at <a href="http://ponymail.info/mboxes/">http:
 <p>(*) The digest depends on the [archiver] generator setting in ponymail.cfg
 If that varies between imports, then duplicates will occur</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/install.centos.html
+++ b/content/docs/install.centos.html
@@ -158,25 +158,13 @@ elasticsearch settings once Pony mail is up and running.</p>
 detailed information about archiving messages, OAuth, mail settings and
 much more.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/install.debian.html
+++ b/content/docs/install.debian.html
@@ -105,25 +105,13 @@ elasticsearch settings once Pony mail is up and running.</p>
 detailed information about archiving messages, OAuth, mail settings and
 much more.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/install.fedora.html
+++ b/content/docs/install.fedora.html
@@ -133,25 +133,13 @@ elasticsearch settings once Pony mail is up and running.</p>
 detailed information about archiving messages, OAuth, mail settings and
 much more.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/install.ubuntu.html
+++ b/content/docs/install.ubuntu.html
@@ -124,25 +124,13 @@ elasticsearch settings once Pony mail is up and running.</p>
 detailed information about archiving messages, OAuth, mail settings and
 much more.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/docs/installing.html
+++ b/content/docs/installing.html
@@ -217,25 +217,13 @@ setups.
 N.B. At present, all the generators have issues, see (#176 #177 #178)
 Please see <a href="archiving.html#usingtherightidgenerator">this paragraph</a> about document ID generators.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -258,25 +258,13 @@ Verify:
 <li>Fix base64 decoding of certain files (#384)</li>
 </ul>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/index.html
+++ b/content/index.html
@@ -40,8 +40,7 @@ per second.  It allows you to browse, search, and interact with mailing lists
 including creating replies to mailing list threads.</p>
 <p>Apache Pony Mail uses OAuth2 (Google, GitHub,
 Facebook etc) for authentication to allow viewing private lists, and uses
-ElasticSearch for storage and searching.  Licensed under the Apache License 2.0
-and undergoing Incubation at the Apache Software Foundation (ASF).</p>
+ElasticSearch for storage and searching.  Licensed under the Apache License 2.0.</p>
 <h3 id='samplescreenshot'>Sample Screenshot<a href='#samplescreenshot' style='color: rgba(0,0,0,0);'>&para;</a></h3>
 <p><img alt="Ponies" src="images/demo.png" /></p>
 <p>Pony Mail works in both public, private and mixed-mode, allowing you
@@ -90,25 +89,13 @@ list size and available bandwidth.</p>
 <li>Have it work with ES with auth mode or via HTTPS</li>
 </ul>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/source.html
+++ b/content/source.html
@@ -42,25 +42,13 @@
 <p>e.g. <code>git clone -b asf-site https://gitbox.apache.org/repos/asf/incubator-ponymail-site.git ponymail-site</code></p>
 <p>See the BUILDING.txt file in the repo for instructions.</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/content/support.html
+++ b/content/support.html
@@ -78,25 +78,13 @@ https://github.com/apache/incubator-ponymail-site/issues](https://github.com/apa
 <h2 id='securityissues'>Security issues<a href='#securityissues' style='color: rgba(0,0,0,0);'>&para;</a></h2>
 <p>Security issues and inquiries should be sent to: security@apache.org</p>
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>

--- a/source/markdown/contribute.md
+++ b/source/markdown/contribute.md
@@ -19,7 +19,7 @@ To contribute to Pony Mail, follow these steps:
 
 * [Fork the repo](/source.html)
 * Subscribe to the Pony Mail dev list:
-    * Either send an email to dev-subscribe@ponymail.incubator.apache.org OR
+    * Either send an email to dev-subscribe@ponymail.apache.org OR
     * Visit [https://lists.apache.org/list.html?dev@ponymail.apache.org](https://lists.apache.org/list.html?dev@ponymail.apache.org) (You can use Google+ or ASF OAuth)
 * Find something to fix or help out with.
 * Let us know what you want to do by opening an [issue](https://github.com/apache/incubator-ponymail-foal/issues) or a pull request.

--- a/source/markdown/docs/CONTRIBUTING.md
+++ b/source/markdown/docs/CONTRIBUTING.md
@@ -17,14 +17,14 @@ and pull requests are welcome.
 ## Mailing lists ##
 
 Developers list:
- - list: dev@ponymail.incubator.apache.org
- - subscribe addr: dev-subscribe@ponymail.incubator.apache.org
- - Online version: http://lists.apache.org/list.html?dev@ponymail.incubator.apache.org
+ - list: dev@ponymail.apache.org
+ - subscribe addr: dev-subscribe@ponymail.apache.org
+ - Online version: http://lists.apache.org/list.html?dev@ponymail.apache.org
     
 Issues list:
- - list: issues@ponymail.incubator.apache.org
- - subscribe addr: issues-subscribe@ponymail.incubator.apache.org
- - Online version: http://lists.apache.org/list.html?bugs@ponymail.incubator.apache.org
+ - list: issues@ponymail.apache.org
+ - subscribe addr: issues-subscribe@ponymail.apache.org
+ - Online version: http://lists.apache.org/list.html?bugs@ponymail.apache.org
 
 ## Chat ##
     

--- a/source/markdown/index.md
+++ b/source/markdown/index.md
@@ -5,8 +5,7 @@ including creating replies to mailing list threads.
 
 Apache Pony Mail uses OAuth2 (Google, GitHub,
 Facebook etc) for authentication to allow viewing private lists, and uses
-ElasticSearch for storage and searching.  Licensed under the Apache License 2.0
-and undergoing Incubation at the Apache Software Foundation (ASF).
+ElasticSearch for storage and searching.  Licensed under the Apache License 2.0.
 
 ### Sample Screenshot ###
 ![Ponies](images/demo.png)

--- a/source/template.html
+++ b/source/template.html
@@ -36,25 +36,13 @@
 </div>
 %CONTENT%
 <div style="display: inline-block; background: #BBB; margin: -10px; padding: 10px;">
-    <h4><a id="disclaimer"></a>Disclaimer</h4>
-<div style="width: 65%; float: left;">
+<div style="width: 80%; float: left;">
 <p style="line-height: 12pt;">
-    Apache Pony Mail is an effort undergoing incubation at
-    The Apache Software Foundation (ASF), sponsored by the <a href="https://incubator.apache.org">
-    Apache Incubator</a>. Incubation is required of all newly accepted projects
-    until a further review indicates that the infrastructure,
-    communications, and decision making process have stabilized in a
-    manner consistent with other successful ASF projects. While
-    incubation status is not necessarily a reflection of the
-    completeness or stability of the code, it does indicate that the
-    project has yet to be fully endorsed by the ASF.
+    Apache Pony Mail is a project of the
+    <a href="https://www.apache.org/">Apache Software Foundation</a>.
 </p>
 </div>
-<div style="width: 20%; float: left; padding-top: 16px; margin-left: -8px;">
-<a href="https://incubator.apache.org"><img src="https://incubator.apache.org/images/incubator_feather_egg_logo_sm.png"/></a>
-</div>
-<div style="width: 15%; float: left; line-height: 15px; padding-left: 22px;">
-    <a class="item" target="_blank" href="https://incubator.apache.org/">Apache Incubator</a><br/>
+<div style="width: 20%; float: left; line-height: 15px; padding-left: 22px;">
             <a class="item" target="_blank" href="https://www.apache.org/">About the ASF<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/policies/conduct.html">Code of Conduct<span></span></a><br/>
             <a class="item" target="_blank" href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a><br/>


### PR DESCRIPTION
- Remove incubation disclaimer, egg logo, and Incubator links from the site-wide footer template
- Remove "undergoing Incubation" text from the homepage
- Replace ponymail.incubator.apache.org email addresses with ponymail.apache.org in contribute.md and docs/CONTRIBUTING.md

Note: GitHub repo URLs (incubator-ponymail-foal etc) and dist paths still reference "incubator" and will be updated after the Infra repo rename is complete.